### PR TITLE
card display

### DIFF
--- a/lib/pointing_party/card.ex
+++ b/lib/pointing_party/card.ex
@@ -5,9 +5,12 @@ defmodule PointingParty.Card do
   alias PointingParty.Repo
   alias PointingParty.Card
 
+  def points_range, do: [0, 1, 3, 5]
+
   schema "cards" do
     field :description, :string
     field :title, :string
+    field :points, :integer
 
     timestamps()
   end
@@ -15,8 +18,9 @@ defmodule PointingParty.Card do
   @doc false
   def changeset(card, attrs) do
     card
-    |> cast(attrs, [:title, :description])
+    |> cast(attrs, [:title, :description, :points])
     |> validate_required([:title, :description])
+    |> validate_inclusion(:points, Card.points_range)
   end
 
   def get!(id) do

--- a/lib/pointing_party/card.ex
+++ b/lib/pointing_party/card.ex
@@ -5,7 +5,6 @@ defmodule PointingParty.Card do
   alias PointingParty.Repo
   alias PointingParty.Card
 
-  def points_range, do: [0, 1, 3, 5]
 
   schema "cards" do
     field :description, :string
@@ -15,12 +14,14 @@ defmodule PointingParty.Card do
     timestamps()
   end
 
+  def points_range, do: [0, 1, 3, 5]
+
   @doc false
   def changeset(card, attrs) do
     card
     |> cast(attrs, [:title, :description, :points])
     |> validate_required([:title, :description])
-    |> validate_inclusion(:points, Card.points_range)
+    |> validate_inclusion(:points, Card.points_range())
   end
 
   def get!(id) do

--- a/lib/pointing_party_web/controllers/card_controller.ex
+++ b/lib/pointing_party_web/controllers/card_controller.ex
@@ -5,6 +5,7 @@ defmodule PointingPartyWeb.CardController do
   def index(conn, _params) do
     # temporary, just to get something on the page for now
     card = Card.first()
-    render(conn, "index.html", card: card)
+    points = Card.points_range()
+    render(conn, "index.html", card: card, points: points)
   end
 end

--- a/lib/pointing_party_web/templates/card/index.html.eex
+++ b/lib/pointing_party_web/templates/card/index.html.eex
@@ -10,10 +10,13 @@
         <div class="col-2">
           <label for="storyPoints">Story Points</label>
           <select class="form-control" id="storyPoints">
-            <option>0</option>
-            <option>1</option>
-            <option>3</option>
-            <option>5</option>
+            <%= Enum.map(@points, fn point ->  %>
+              <%= if @card.points == point do %>
+                <option selected="selected'"><%= point %></option>
+              <% else %>
+                <option><%= point %></option>
+              <% end %>
+            <% end) %>
           </select>
         </div>
       </div>

--- a/lib/pointing_party_web/templates/card/index.html.eex
+++ b/lib/pointing_party_web/templates/card/index.html.eex
@@ -21,6 +21,6 @@
     <a href="#" class="btn btn-primary">Calculate Points</a>
   </div>
   <div class="card-footer text-muted">
-    <%= @card.inserted_at %>
+    created at: <%= @card.inserted_at %>
   </div>
 </div>

--- a/lib/pointing_party_web/templates/card/index.html.eex
+++ b/lib/pointing_party_web/templates/card/index.html.eex
@@ -1,1 +1,26 @@
-<%= @card.title %>
+
+<div class="card text-left">
+  <div class="card-header">
+    <h2><%= @card.title %></h2>
+  </div>
+  <div class="card-body">
+    <p class="card-text"><%= @card.description %></p>
+    <div class="form-group text-left">
+      <div class="form-row align-items-center">
+        <div class="col-2">
+          <label for="storyPoints">Story Points</label>
+          <select class="form-control" id="storyPoints">
+            <option>0</option>
+            <option>1</option>
+            <option>3</option>
+            <option>5</option>
+          </select>
+        </div>
+      </div>
+  </div>
+    <a href="#" class="btn btn-primary">Calculate Points</a>
+  </div>
+  <div class="card-footer text-muted">
+    <%= @card.inserted_at %>
+  </div>
+</div>

--- a/lib/pointing_party_web/templates/layout/app.html.eex
+++ b/lib/pointing_party_web/templates/layout/app.html.eex
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>PointingParty</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
   </head>
   <body>

--- a/priv/repo/migrations/20190714140153_add_points_to_cards.exs
+++ b/priv/repo/migrations/20190714140153_add_points_to_cards.exs
@@ -1,0 +1,9 @@
+defmodule PointingParty.Repo.Migrations.AddPointsToCards do
+  use Ecto.Migration
+
+  def change do
+    alter table("cards") do
+      add :points, :integer, default: 0
+    end
+  end
+end


### PR DESCRIPTION
As a user
When I visit `/cards`
Then I see the first card to estimate 

--
This PR 
* pulls in Bootstrap from the CDN for some basic styling
* Lays out the design for showing a single card with "story points" form field
* Adds `points` to cards table and schema, validates point inclusion in Fibonacci sequence (figured we could estimate using Fibonacci but happy to change to any other scale)

<img width="1435" alt="Screen Shot 2019-07-14 at 9 50 38 AM" src="https://user-images.githubusercontent.com/8999596/61184539-033b6f80-a61d-11e9-94c9-55c64c512a49.png">

Happy to tweak the layout if anyone has specific thoughts but my CSS skills are admittedly limited :) 